### PR TITLE
add digestof to uninspectable output

### DIFF
--- a/inspect/inspect.pony
+++ b/inspect/inspect.pony
@@ -104,7 +104,9 @@ primitive Inspect
       end
       output.append(apply(ary))
     else
-      return "<uninspectable>"
+      output.>append("<uninspectable")
+            .>append((digestof input).string())
+            .>append(">")
     end
     
     output

--- a/inspect/inspect.pony
+++ b/inspect/inspect.pony
@@ -104,7 +104,7 @@ primitive Inspect
       end
       output.append(apply(ary))
     else
-      output.>append("<uninspectable")
+      output.>append("<uninspectable:")
             .>append((digestof input).string())
             .>append(">")
     end


### PR DESCRIPTION
uninspectable output now is printed as:
``<uninspectable:12345>`` where 12345 is the ``digestof`` of the given input.