### PR TITLE
Add missing FFI signatures

### DIFF
--- a/inspect/_stdout.pony
+++ b/inspect/_stdout.pony
@@ -1,3 +1,5 @@
+use @pony_os_std_write[None](file: Pointer[None] tag, buffer: Pointer[U8] tag, size: USize)
+use @pony_os_stdout[Pointer[U8]]()
 
 primitive _STDOUT
   """
@@ -5,7 +7,7 @@ primitive _STDOUT
   This is for debugging purposes only, as it is not concurrency-safe.
   """
   fun write(data: String box) =>
-    @pony_os_std_write[None](@pony_os_stdout[Pointer[U8]](), data.cstring(), data.size())
+    @pony_os_std_write(@pony_os_stdout(), data.cstring(), data.size())
   
   fun write_line(data: String box) =>
     write(data + "\n")


### PR DESCRIPTION
Current Pony versions require that you predeclare FFI function signatures with `use`